### PR TITLE
iFrame issue github markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ data.
 ## Anomalize In 2 Minutes
 
 <a href="http://www.youtube.com/watch?feature=player_embedded&v= Gk_HwjhlQJs" target="_blank"><img src="http://img.youtube.com/vi/Gk_HwjhlQJs/0.jpg" 
-alt="Anomalize" width="100%" height="350"/></a>
+alt="Anomalize" width="70%" height="350"/></a>
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ data.
 
 ## Anomalize In 2 Minutes
 
-<iframe width="100%" height="350" src="https://www.youtube.com/embed/Gk_HwjhlQJs" frameborder="1" allow="autoplay; encrypted-media" allowfullscreen>
-
-</iframe>
+<a href="http://www.youtube.com/watch?feature=player_embedded&v= Gk_HwjhlQJs" target="_blank"><img src="http://img.youtube.com/vi/Gk_HwjhlQJs/0.jpg" 
+alt="Anomalize" width="100%" height="350"/></a>
 
 ## Installation
 


### PR DESCRIPTION
Because of this issue: https://github.com/kevinSuttle/github/issues/17
`<iframe>` and `<script>` tags aren't allowed.

Followed this hack for now: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#youtube-videos