### PR TITLE
Add support for na.rm in 'gesd' method.

### DIFF
--- a/R/anomalize.R
+++ b/R/anomalize.R
@@ -13,6 +13,8 @@
 #' @param verbose A boolean. If `TRUE`, will return a list containing useful information
 #' about the anomalies. If `FALSE`, just returns the data expanded with the anomalies and
 #' the lower (l1) and upper (l2) bounds.
+#' @param na.rm Should NA values be removed when calculating outliers? Only
+#' applicable to `"gesd"` method.
 #'
 #' @return Returns a `tibble` / `tbl_time` object or list depending on the value of `verbose`.
 #'
@@ -88,7 +90,7 @@
 #'
 #' @export
 anomalize <- function(data, target, method = c("iqr", "gesd"),
-                      alpha = 0.05, max_anoms = 0.20, verbose = FALSE) {
+                      alpha = 0.05, max_anoms = 0.20, verbose = FALSE, na.rm = FALSE) {
     UseMethod("anomalize", data)
 }
 
@@ -100,7 +102,7 @@ anomalize.default <- function(data, target, method = c("iqr", "gesd"),
 
 #' @export
 anomalize.tbl_df <- function(data, target, method = c("iqr", "gesd"),
-                      alpha = 0.05, max_anoms = 0.20, verbose = FALSE) {
+                      alpha = 0.05, max_anoms = 0.20, verbose = FALSE, na.rm = FALSE) {
 
     # Checks
     if (missing(target)) stop('Error in anomalize(): argument "target" is missing, with no default', call. = FALSE)
@@ -130,6 +132,7 @@ anomalize.tbl_df <- function(data, target, method = c("iqr", "gesd"),
         outlier_list <- anomalize::gesd(x         = x,
                                         alpha     = alpha,
                                         max_anoms = max_anoms,
+                                        na.rm     = na.rm,
                                         verbose   = TRUE)
 
     } else {

--- a/R/anomalize_methods.R
+++ b/R/anomalize_methods.R
@@ -132,7 +132,7 @@ iqr <- function(x, alpha = 0.05, max_anoms = 0.2, verbose = FALSE) {
 
 #' @export
 #' @rdname anomalize_methods
-gesd <- function(x, alpha = 0.05, max_anoms = 0.2, verbose = FALSE) {
+gesd <- function(x, alpha = 0.05, max_anoms = 0.2, verbose = FALSE, na.rm = FALSE) {
 
   # Variables
   n <- length(x)
@@ -151,12 +151,12 @@ gesd <- function(x, alpha = 0.05, max_anoms = 0.2, verbose = FALSE) {
   for (i in seq_len(r)) {
 
     # Compute test statistic
-    median_new[i] <- median(x_new)
-    mad_new[i] <- mad(x_new)
+    median_new[i] <- median(x_new, na.rm = na.rm)
+    mad_new[i] <- mad(x_new, na.rm = na.rm)
 
-    z <- abs(x_new - median(x_new)) / (mad(x_new) + .Machine$double.eps) # Z-scores
+    z <- abs(x_new - median(x_new, na.rm = na.rm)) / (mad(x_new, na.rm = na.rm) + .Machine$double.eps) # Z-scores
 
-    max_ind <- which(z == max(z), arr.ind = T)[1] # in case of ties, return first one
+    max_ind <- which(z == max(z, na.rm = na.rm), arr.ind = T)[1] # in case of ties, return first one
     R[i] <- z[max_ind] # max Z-score
     outlier_val[i] <- x_new[max_ind] # removed outlier observation values
     outlier_ind[i] <- which(x_new[max_ind] == x, arr.ind = T)[1] # index of removed outlier observation values

--- a/man/anomalize.Rd
+++ b/man/anomalize.Rd
@@ -4,8 +4,15 @@
 \alias{anomalize}
 \title{Detect anomalies using the tidyverse}
 \usage{
-anomalize(data, target, method = c("iqr", "gesd"), alpha = 0.05,
-  max_anoms = 0.2, verbose = FALSE)
+anomalize(
+  data,
+  target,
+  method = c("iqr", "gesd"),
+  alpha = 0.05,
+  max_anoms = 0.2,
+  verbose = FALSE,
+  na.rm = FALSE
+)
 }
 \arguments{
 \item{data}{A \code{tibble} or \code{tbl_time} object.}
@@ -26,6 +33,9 @@ to incorrectly classifying "normal" observations.}
 \item{verbose}{A boolean. If \code{TRUE}, will return a list containing useful information
 about the anomalies. If \code{FALSE}, just returns the data expanded with the anomalies and
 the lower (l1) and upper (l2) bounds.}
+
+\item{na.rm}{Should NA values be removed when calculating outliers? Only
+applicable to \code{"gesd"} method.}
 }
 \value{
 Returns a \code{tibble} / \code{tbl_time} object or list depending on the value of \code{verbose}.
@@ -51,13 +61,13 @@ each with benefits.
 
 \strong{IQR}:
 
-The IQR Method uses an innerquartile range of 25% and 75% to establish a baseline distribution around
+The IQR Method uses an innerquartile range of 25\% and 75\% to establish a baseline distribution around
 the median. With the default \code{alpha = 0.05}, the limits are established by expanding
 the 25/75 baseline by an IQR Factor of 3 (3X). The IQR Factor = 0.15 / alpha (hense 3X with alpha = 0.05).
 To increase the IQR Factor controling the limits, decrease the alpha, which makes
 it more difficult to be an outlier. Increase alpha to make it easier to be an outlier.
 
-The IQR method is used in \href{https://github.com/robjhyndman/forecast}{forecast::tsoutliers()}.
+The IQR method is used in \href{https://github.com/robjhyndman/forecast}{\code{forecast::tsoutliers()}}.
 
 \strong{GESD}:
 
@@ -68,7 +78,7 @@ drops below the critical value, all outliers are considered removed. Because thi
 involves continuous updating via a loop, it is slower than the IQR method. However, it
 tends to be the best performing method for outlier removal.
 
-The GESD method is used in \href{https://github.com/twitter/AnomalyDetection}{AnomalyDection::AnomalyDetectionTs()}.
+The GESD method is used in \href{https://github.com/twitter/AnomalyDetection}{\code{AnomalyDection::AnomalyDetectionTs()}}.
 }
 \examples{
 

--- a/man/anomalize_methods.Rd
+++ b/man/anomalize_methods.Rd
@@ -8,7 +8,7 @@
 \usage{
 iqr(x, alpha = 0.05, max_anoms = 0.2, verbose = FALSE)
 
-gesd(x, alpha = 0.05, max_anoms = 0.2, verbose = FALSE)
+gesd(x, alpha = 0.05, max_anoms = 0.2, verbose = FALSE, na.rm = FALSE)
 }
 \arguments{
 \item{x}{A vector of numeric data.}
@@ -21,6 +21,9 @@ to incorrectly classifying "normal" observations.}
 
 \item{verbose}{A boolean. If \code{TRUE}, will return a list containing useful information
 about the anomalies. If \code{FALSE}, just returns a vector of "Yes" / "No" values.}
+
+\item{na.rm}{Should NA values be removed when calculating outliers? Only
+applicable to \code{"gesd"} method.}
 }
 \value{
 Returns character vector or list depending on the value of \code{verbose}.
@@ -45,8 +48,8 @@ gesd(x, alpha = 0.05, max_anoms = 0.2, verbose = TRUE)
 }
 \references{
 \itemize{
-\item The IQR method is used in \href{https://github.com/robjhyndman/forecast/blob/master/R/clean.R}{forecast::tsoutliers()}
-\item The GESD method is used in Twitter's \href{https://github.com/twitter/AnomalyDetection}{AnomalyDetection} package and is also available as a function in \href{https://github.com/raunakms/GESD/blob/master/runGESD.R}{@raunakms's GESD method}
+\item The IQR method is used in \href{https://github.com/robjhyndman/forecast/blob/master/R/clean.R}{\code{forecast::tsoutliers()}}
+\item The GESD method is used in Twitter's \href{https://github.com/twitter/AnomalyDetection}{\code{AnomalyDetection}} package and is also available as a function in \href{https://github.com/raunakms/GESD/blob/master/runGESD.R}{@raunakms's GESD method}
 }
 }
 \seealso{


### PR DESCRIPTION
I was not able to execute `anomalize::anomalize` with `method='gesd'` if many NA values were present. This solves that problem by using the `na.rm` functionality within base R.